### PR TITLE
Change in settings initialization.

### DIFF
--- a/bootstrap3/settings.py
+++ b/bootstrap3/settings.py
@@ -13,7 +13,7 @@ BOOTSTRAP3_DEFAULTS = {
 }
 
 BOOTSTRAP3 = getattr(settings, 'BOOTSTRAP3', {})
-BOOTSTRAP3.update(BOOTSTRAP3_DEFAULTS)
+BOOTSTRAP3 = dict(BOOTSTRAP3_DEFAULTS.items() + BOOTSTRAP3.items())
 
 
 def bootstrap_url(postfix):


### PR DESCRIPTION
The current way of initializing settings overwrites the user's settings with the defaults. With the suggested change, only undefined keys or keys with None values are set.
