### PR TITLE
Fix FileInput widget styling

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -45,7 +45,10 @@ def render_field(field, inline=False, horizontal=False, field_class=None, label_
     widget_attr_title = getattr(field.field.widget.attrs, 'title', '')
 
     # Class to add to field element
-    form_control_class = 'form-control'
+    if isinstance(field.field.widget, widgets.FileInput):
+        form_control_class = ''
+    else:
+        form_control_class = 'form-control'
     # Convert this widget from HTML list to a wrapped class?
     list_to_class = False
     # Wrap rendered field in its own label?


### PR DESCRIPTION
http://getbootstrap.com/css/#forms-example

Bootstrap 3 does not suggest using .form-control on file selection widgets. Doing so messes up the look of the widget.

Example.

![input-with-form-control](https://f.cloud.github.com/assets/46186/1086261/aea8c406-15f7-11e3-8056-b9ea29fea7f3.png)
