### PR TITLE
Fix the {% block %} definition in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Bootstrap 3 integration with Django. Easily generate Bootstrap3 compatible HTML 
         <form action="/url/to/submit/" method="post" class="form">
                 {% csrf_token %}
                 {% bootstrap_form form %}
-                {% bootstrap_form_buttons %}
+                {% block bootstrap_form_buttons %}
                         <button type="submit" class="btn btn-primary">
                                 {% bootstrap_icon "star" %} Submit
                         </button>
-                {% end_bootstrap_form_buttons %}
+                {% endblock bootstrap_form_buttons %}
         </form>
 
 ## Requirements


### PR DESCRIPTION
Hey folks, i just get in touch in the Bootstrap3, Django and the django-registration module... so i saw that the `{% block %}` of buttons in the form was defined wrong... i think it was at least.
Congrats for the code, is really helpful :)
