### PR TITLE
Fixed one more issue with unicode text

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -13,6 +13,12 @@ from .icons import render_icon
 FORM_GROUP_CLASS = 'form-group'
 
 
+def to_unicode(string):
+    if isinstance(string, str):
+        return string.decode("utf-8", "ignore")
+    return unicode(string)
+
+
 def render_formset(formset, **kwargs):
     if not isinstance(formset, BaseFormSet):
         raise BootstrapError('Parameter "formset" should contain a valid Django FormSet.')
@@ -188,8 +194,9 @@ def render_field_and_label(field, label, field_class='', label_class='', layout=
     html = field
     if field_class:
         html = '<div class="%s">%s</div>' % (field_class, html)
+    html = to_unicode(html)
     if label:
-        html = render_label(label, label_class=label_class) + html
+        html = render_label(to_unicode(label), label_class=label_class) + html
     return html
 
 


### PR DESCRIPTION
django-bootstrap3 does not properly handle unicode chars as form field values.

`File ".../ve/local/lib/python2.7/site-packages/bootstrap3/forms.py", line 192, in render_field_and_label
  html = render_label(label, label_class=label_class) + html
UnicodeDecodeError: ‘ascii’ codec can't decode byte 0xc3 in position 224: ordinal not in range(128)`
