### PR TITLE
Adds a {{ bootstrap_messages }} template tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Bootstrap 3 integration with Django. Easily generate Bootstrap3 compatible HTML 
         {% bootstrap_css %}
         {% bootstrap_javascript %}
         
+        {# Display django.contrib.messages as Bootstrap alerts }
+        {% bootstrap_messages %}
+
         {# Display a form #}
         
         <form action="/url/to/submit/" method="post" class="form">

--- a/bootstrap3/templates/bootstrap3/messages.html
+++ b/bootstrap3/templates/bootstrap3/messages.html
@@ -1,0 +1,6 @@
+{% for message in messages %}
+    <div class="alert{% if message.tags %} alert-{{ message.tags }}{% endif %}" data-dismiss="alert">
+        <a class="close" data-dismiss="alert" href="#">&times;</a>
+        {{ message }}
+    </div>
+{% endfor %}

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -1,6 +1,7 @@
 from math import floor
 import re
 from django import template
+from django.template.loader import get_template
 
 from ..bootstrap import jquery_url, javascript_url, css_url
 from ..icons import render_icon
@@ -123,6 +124,14 @@ class ButtonsNode(template.Node):
             return ''
         else:
             return output
+
+
+@register.simple_tag(takes_context=True)
+def bootstrap_messages(context, *args, **kwargs):
+    """
+    Show django.contrib.messages Messages in Bootstrap alert containers
+    """
+    return get_template('bootstrap3/messages.html').render(context)
 
 
 @register.inclusion_tag('bootstrap3/pagination.html')

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -214,3 +214,38 @@ class IconTest(TestCase):
     def test_icon(self):
         res = render_template('{% bootstrap_icon "star" %}')
         self.assertEqual(res.strip(), '<span class="glyphicon glyphicon-star"></span>')
+
+
+class MessagesTest(TestCase):
+
+    def test_messages(self):
+        class FakeMessage(object):
+            """
+            Follows the `django.contrib.messages.storage.base.Message` API.
+            """
+            def __init__(self, message, tags):
+                self.tags = tags
+                self.message = message
+
+            def __str__(self):
+                return self.message
+
+        messages = [FakeMessage("hello", "warning")]
+        res = render_template('{% bootstrap_messages messages %}', messages=messages)
+        expected = """
+    <div class="alert alert-warning" data-dismiss="alert">
+        <a class="close" data-dismiss="alert" href="#">&times;</a>
+        hello
+    </div>
+"""
+        self.assertEqual(res.strip(), expected.strip())
+
+        messages = [FakeMessage("hello", None)]
+        expected = """
+    <div class="alert" data-dismiss="alert">
+        <a class="close" data-dismiss="alert" href="#">&times;</a>
+        hello
+    </div>
+"""
+        res = render_template('{% bootstrap_messages messages %}', messages=messages)
+        self.assertEqual(res.strip(), expected.strip())

--- a/demo/demo/templates/demo/base.html
+++ b/demo/demo/templates/demo/base.html
@@ -13,6 +13,8 @@
             <a href="/form_inline">form_inline</a>
         </p>
 
+        {% bootstrap_messages %}
+
         {% block content %}(no content){% endblock %}
     </div>
 


### PR DESCRIPTION
Brings in support for Bootstrap alert containers, matched
to django.contrib.messages capabilities. Ported from
django-bootstrap-toolkit. Includes unit tests.
