### PR TITLE
Fields not rendering custom attributes from widgets

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -93,7 +93,7 @@ def render_field(field, layout='', field_class=None, label_class=None, show_labe
     if widget_is_required:
         field.field.widget.attrs['required'] = ''
     # Render the field
-    rendered_field = force_text(field)
+    rendered_field = field.as_widget(attrs=field.field.widget.attrs)
     # Return class and placeholder attributes to original settings
     field.field.widget.attrs['class'] = widget_attr_class
     field.field.widget.attrs['placeholder'] = widget_attr_placeholder


### PR DESCRIPTION
`__unicode__(bound_field)` or `force_text(bound_field)` does not works as expected when you are using a widget that  overrides the `render` method, adding custom attributes.

Instead you can call `field.as_widget` passing the attributes you want, so it will render the custom attributes too.
