### PR TITLE
fix for python 3.x incompatibility in pagination

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -207,7 +207,7 @@ def get_pagination_context(page, pages_to_show=11,
         pages_forward = None
         if first_page > 1:
             first_page -= 1
-        if pages_back > 1:
+        if pages_back is not None and pages_back > 1:
             pages_back -= 1
         else:
             pages_back = None


### PR DESCRIPTION
bootstrap_pagination tag throws `TypeError: unorderable types: NoneType() > int()` in python 3.x. Tested on 3.3.2
