### PR TITLE
Bugfix for python3 compatibility; unicode() function is undefined in 3.x

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -6,6 +6,7 @@ from math import floor
 
 from django import template
 from django.template.loader import get_template
+from django.utils import six
 
 from ..bootstrap import css_url, javascript_url, jquery_url
 from ..forms import (render_button, render_field, render_field_and_label,
@@ -470,7 +471,7 @@ def get_pagination_context(page, pages_to_show=11,
         # Append proper character to url
     if url:
         # Remove existing page GET parameters
-        url = unicode(url)
+        url = six.u(url)
         url = re.sub(r'\?page\=[^\&]+', '?', url)
         url = re.sub(r'\&page\=[^\&]+', '', url)
         # Append proper separator
@@ -482,7 +483,7 @@ def get_pagination_context(page, pages_to_show=11,
     if extra:
         if not url:
             url = '?'
-        url += unicode(extra) + '&'
+        url += six.u(extra) + '&'
     if url:
         url = url.replace('?&', '?')
     # Set CSS classes,see twitter.github.io/bootstrap/components.html#pagination


### PR DESCRIPTION
Pagination wasn't working in 3.x if the "url" argument is passed because `unicode` function no longer exists.
