### PR TITLE
Add 'optional' and 'required' classes to form group

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -172,6 +172,12 @@ def render_field(field, layout='', form_group_class=FORM_GROUP_CLASS,
     elif field.form.is_bound:
         form_group_class = add_css_class(form_group_class, 'has-success')
 
+    # Required and optional classes to the form group
+    if field.field.required:
+        form_group_class = add_css_class(form_group_class, 'required')
+    else:
+        form_group_class = add_css_class(form_group_class, 'optional')
+
     return render_form_group(content, form_group_class)
 
 


### PR DESCRIPTION
resolves #66

Bootstrap doesn't give any specific guidelines how to visually distinguish optional and required fields. Thus this matter can be left open to custom styling by adding classes `required` and `optional` to the 'form-group' element.
