### PR TITLE
Tags fix for multiple extra tags

### DIFF
--- a/bootstrap3/templates/bootstrap3/messages.html
+++ b/bootstrap3/templates/bootstrap3/messages.html
@@ -1,5 +1,5 @@
 {% for message in messages %}
-    <div class="alert{% if message.tags %} alert-{% if message.tags == 'error' %}danger{% else %}{{ message.tags }}{% endif %}{% endif %} alert-dismissable">
+    <div class="alert{% if message.tags %} alert-{% if 'error' in message.tags %}danger {% endif %}{{ message.tags }}{% endif %} alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         {{ message|safe }}
     </div>


### PR DESCRIPTION
When multiple extra tags are added into messages, the old code for this template wasn't accurately including "alert-danger".
