### PR TITLE
Changed &times; to its decimal representative &#215;

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -67,7 +67,7 @@ class FormRenderer(object):
             return '''
                 <div class="alert alert-danger alert-dismissable alert-link">
                 <button class="close" data-dismiss="alert" aria-hidden="true">
-                &times;</button>{errors}</div>\n'''.format(errors=errors)
+                &#215;</button>{errors}</div>\n'''.format(errors=errors)
         return ''
 
     def render(self):


### PR DESCRIPTION
So that taconite doesn't break when parsing the HTML

Previous issue with entitites:
https://github.com/dyve/django-bootstrap3/issues/94
