### PR TITLE
Fixed bug in form_errors template

### DIFF
--- a/bootstrap3/templates/bootstrap3/form_errors.html
+++ b/bootstrap3/templates/bootstrap3/form_errors.html
@@ -1,5 +1,5 @@
 <div class="alert alert-danger alert-dismissable alert-link">
-    <button class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
+    <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&#215;</button>
     {% for error in errors %}
         {{ error }}{% if not forloop.last %}<br>{% endif %}
     {% endfor %}


### PR DESCRIPTION
When the close button is inside a form and the enter key is pressed, then the submit event of the form is released.
