### PR TITLE
Issue 114

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -7,7 +7,7 @@ from django.utils.importlib import import_module
 
 # Default settings
 BOOTSTRAP3_DEFAULTS = {
-    'jquery_url': '//code.jquery.com/jquery.min.js',
+    'jquery_url': '//code.jquery.com/jquery.js',
     'base_url': '//netdna.bootstrapcdn.com/bootstrap/3.1.1/',
     'css_url': None,
     'theme_url': None,

--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -33,6 +33,14 @@ def render_form(form, layout='', **kwargs):
     return renderer_cls(form, layout, **kwargs).render()
 
 
+def render_form_errors(form, layout='', type='all', **kwargs):
+    """
+    Render form errors to a Bootstrap layout
+    """
+    renderer_cls = get_form_renderer(layout)
+    return renderer_cls(form, layout, **kwargs).render_errors(type)
+
+
 def render_field(field, layout='', **kwargs):
     """
     Render a formset to a Bootstrap layout

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -53,15 +53,22 @@ class FormRenderer(object):
             ))
         return '\n'.join(rendered_fields)
 
-    def get_form_errors(self):
+    def get_fields_errors(self):
         form_errors = []
         for field in self.form:
             if field.is_hidden and field.errors:
                 form_errors += field.errors
-        return form_errors + self.form.non_field_errors()
+        return form_errors
 
-    def render_errors(self):
-        form_errors = self.get_form_errors()
+    def render_errors(self, type='all'):
+        form_errors = None
+        if type == 'all':
+            form_errors = self.get_fields_errors() + self.form.non_field_errors()
+        elif type == 'fields':
+            form_errors = self.get_fields_errors()
+        elif type == 'non_fields':
+            form_errors = self.form.non_field_errors()
+
         if form_errors:
             return get_template(
                 'bootstrap3/form_errors.html').render(Context({

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -11,7 +11,7 @@ from django.template.loader import get_template
 from ..bootstrap import css_url, javascript_url, jquery_url, theme_url, get_bootstrap_setting
 from ..html import render_link_tag
 from ..forms import render_button, render_field, render_field_and_label, render_form, render_form_group, render_formset, \
-    render_label
+    render_label, render_form_errors
 from ..components import render_icon, render_alert
 from ..templates import handle_var, parse_token_contents
 from ..text import force_text
@@ -245,6 +245,31 @@ def bootstrap_form(*args, **kwargs):
         {% bootstrap_form form layout='inline' %}
     """
     return render_form(*args, **kwargs)
+
+
+@register.simple_tag
+def bootstrap_form_errors(*args, **kwargs):
+    """
+    Render form errors
+
+    **Tag name**::
+
+        bootstrap_form_errors
+
+    **Parameters**:
+
+        :args:
+        :kwargs:
+
+    **usage**::
+
+        {% bootstrap_form_errors form %}
+
+    **example**::
+
+        {% bootstrap_form_errors form layout='inline' %}
+    """
+    return render_form_errors(*args, **kwargs)
 
 
 @register.simple_tag

--- a/demo/demo/templates/demo/base.html
+++ b/demo/demo/templates/demo/base.html
@@ -11,6 +11,7 @@
         <p>
             <a href="{% url 'home' %}">home</a>
             <a href="{% url 'form_default' %}">form</a>
+            <a href="{% url 'form_by_field' %}">form_by_field</a>
             <a href="{% url 'form_horizontal' %}">form_horizontal</a>
             <a href="{% url 'form_inline' %}">form_inline</a>
             <a href="{% url 'form_with_files' %}">form_with_files</a>

--- a/demo/demo/templates/demo/form_by_field.html
+++ b/demo/demo/templates/demo/form_by_field.html
@@ -1,0 +1,18 @@
+{% extends 'demo/base.html' %}
+
+{% load bootstrap3 %}
+
+{% block title %}
+    Forms
+{% endblock %}
+
+{% block content %}
+
+    <form role="form" method="post">
+        {% csrf_token %}
+        {% bootstrap_form_errors form type='non_fields' %}
+        {% bootstrap_field form.subject layout='horizontal' %}
+        {% buttons submit='OK' reset="Cancel" %}{% endbuttons %}
+    </form>
+
+{% endblock %}

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.conf.urls import patterns, url
 
 from .views import HomePageView, FormHorizontalView, FormInlineView, PaginationView, FormWithFilesView, \
-    DefaultFormView, MiscView
+    DefaultFormView, MiscView, DefaultFormByFieldView
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -25,6 +25,7 @@ from .views import HomePageView, FormHorizontalView, FormInlineView, PaginationV
 urlpatterns = patterns('',
     url(r'^$', HomePageView.as_view(), name='home'),
     url(r'^form$', DefaultFormView.as_view(), name='form_default'),
+    url(r'^form_by_field$', DefaultFormByFieldView.as_view(), name='form_by_field'),
     url(r'^form_horizontal$', FormHorizontalView.as_view(), name='form_horizontal'),
     url(r'^form_inline$', FormInlineView.as_view(), name='form_inline'),
     url(r'^form_with_files$', FormWithFilesView.as_view(), name='form_with_files'),

--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -33,6 +33,11 @@ class DefaultFormView(FormView):
     form_class = ContactForm
 
 
+class DefaultFormByFieldView(FormView):
+    template_name = 'demo/form_by_field.html'
+    form_class = ContactForm
+
+
 class FormHorizontalView(FormView):
     template_name = 'demo/form_horizontal.html'
     form_class = ContactForm


### PR DESCRIPTION
Add bootstrap_form_errors tag in order to render only the errors. 
You can customize errors passing type = [all | fields | non_fields ] variable
