### PR TITLE
Fixup handling of form group classes

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -20,6 +20,7 @@ BOOTSTRAP3_DEFAULTS = {
     'set_placeholder': True,
     'form_required_class': '',
     'form_error_class': 'has-error',
+    'form_bound_class': 'has-success',
     'formset_renderers':{
         'default': 'bootstrap3.renderers.FormsetRenderer',
     },

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -184,6 +184,7 @@ class FieldRenderer(BaseRenderer):
         # These are set in Django or in the global BOOTSTRAP3 settings, and they can be overwritten in the template
         error_css_class = kwargs.get('error_css_class', '')
         required_css_class = kwargs.get('required_css_class', '')
+        bound_css_class = kwargs.get('bound_css_class', '')
         if error_css_class:
             self.form_error_class = error_css_class
         else:
@@ -193,6 +194,10 @@ class FieldRenderer(BaseRenderer):
         else:
             self.form_required_class = getattr(field.form, 'required_css_class',
                                                get_bootstrap_setting('form_required_class'))
+        if bound_css_class:
+            self.form_bound_class = bound_css_class
+        else:
+            self.form_bound_class = getattr(field.form, 'bound_css_class', get_bootstrap_setting('form_bound_class'))
 
     def restore_widget_attrs(self):
         self.widget.attrs = self.initial_attrs
@@ -353,7 +358,7 @@ class FieldRenderer(BaseRenderer):
             form_group_class = add_css_class(
                 form_group_class, self.form_error_class)
         elif self.field.form.is_bound:
-            form_group_class = add_css_class(form_group_class, 'has-success')
+            form_group_class = add_css_class(form_group_class, self.form_bound_class)
         if self.layout == 'horizontal':
             form_group_class = add_css_class(form_group_class, self.get_size_class(prefix='form-group'))
         return form_group_class

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -145,6 +145,11 @@ class SettingsTest(TestCase):
         res = render_template('{% bootstrap_form form %}', form=form)
         self.assertIn('bootstrap3-err', res)
 
+    def test_bound_class(self):
+        form = TestForm({'sender': 'sender'})
+        res = render_template('{% bootstrap_form form %}', form=form)
+        self.assertIn('bootstrap3-bound', res)
+
 
 class TemplateTest(TestCase):
     def test_empty_template(self):

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -51,7 +51,10 @@ The ``BOOTSTRAP3`` dict variable is contains these settings and defaults:
         'form_required_class': '',
 
         # Class to indicate error (better to set this in your Django form)
-        'form_error_class': '',
+        'form_error_class': 'has-error',
+
+        # Class to indicate the field is bound (better to set this in your Django form)
+        'form_bound_class': 'has-success',
 
         # Renderers (only set these if you have studied the source and understand the inner workings)
         'formset_renderers':{

--- a/testsettings.py
+++ b/testsettings.py
@@ -13,6 +13,7 @@ BOOTSTRAP3 = {
     'javascript_in_head': True,
     'form_required_class': 'bootstrap3-req',
     'form_error_class': 'bootstrap3-err',
+    'form_bound_class': 'bootstrap3-bound',
 }
 
 SECRET_KEY = 'bootstrap3isawesome'


### PR DESCRIPTION
First fix form_required_class and form_error_class handling, the wrong key was read from settings. Then let one override completely the form_error_class. Finally add the same feature to for field that are bound by form_bound_class. Replaces #150.
