### PR TITLE
Correct example from documentation to fit with syntax for bootstrap_form...

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -318,7 +318,7 @@ def bootstrap_field(*args, **kwargs):
 
     **example**::
 
-        {% bootstrap_form form_field form.subject %}
+        {% bootstrap_form form_field %}
     """
     return render_field(*args, **kwargs)
 


### PR DESCRIPTION
... form_field

It appears that  {% bootstrap_form form_field form.subject %} is not making sense in this case, as the usage is stating {% bootstrap_field form_field %}
