### PR TITLE
Drop Django 2.2, add Django 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.1 (in development)
+
+- Add support for Django 4.1.
+- Drop support for Django 2.2 (EOL).
+
 ## 21.2 (2021-12-27)
 
 - Drop support for Django 3.1 (EOL, #632).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The goal of this project is to seamlessly blend Django and Bootstrap 3.
 
 ## Requirements
 
-Python 3.7 or newer with Django >= 2.2 or newer.
+Python 3.7 or newer with Django 3.2 or newer.
 
 ## Documentation
 
@@ -29,7 +29,7 @@ The full documentation is at https://django-bootstrap3.readthedocs.io/
     ```shell script
     pip install django-bootstrap3
     ```
-   
+
    Alternatively, you can install download or clone this repo and call ``pip install -e .``.
 
 2. Add to `INSTALLED_APPS` in your `settings.py`:

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
@@ -44,7 +44,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "Django>=2.2",
+        "Django>=3.2",
         'importlib-metadata<3; python_version<"3.8"',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ isolated_build = True
 envlist =
     lint
     docs
-    py37-django{22,32}
-    py38-django{32,40,main}
-    py39-django{32,40,main}
-    py310-django{32,40,main}
+    py37-django{32}
+    py38-django{32,40,41,main}
+    py39-django{32,40,41,main}
+    py310-django{32,40,41,main}
     check-description
     check-manifest
     coverage
@@ -26,9 +26,9 @@ setenv =
 commands =
     coverage run --parallel-mode manage.py test -v1 --noinput
 deps =
-    django22: Django==2.2.*
     django32: Django==3.2.*
     django40: Django==4.0.*
+    django41: Django==4.1.*
     djangomain: https://github.com/django/django/archive/main.tar.gz
     coverage[toml]
     coveralls


### PR DESCRIPTION
Django 2.2 is no longer supported.
Django 4.1 was recently published.