### PR TITLE
Fix check order of CheckboxSelectMultiple and RadioSelect

### DIFF
--- a/src/bootstrap3/renderers.py
+++ b/src/bootstrap3/renderers.py
@@ -355,10 +355,10 @@ class FieldRenderer(BaseRenderer):
         return f'<div class="row bootstrap3-multi-input"><div class="col-xs-12">{html}</div></div>'
 
     def post_widget_render(self, html):
-        if isinstance(self.widget, RadioSelect):
-            html = self.list_to_class(html, "radio")
-        elif isinstance(self.widget, CheckboxSelectMultiple):
+        if isinstance(self.widget, CheckboxSelectMultiple):
             html = self.list_to_class(html, "checkbox")
+        elif isinstance(self.widget, RadioSelect):
+            html = self.list_to_class(html, "radio")
         elif isinstance(self.widget, SelectDateWidget):
             html = self.fix_date_select_input(html)
         elif isinstance(self.widget, ClearableFileInput):


### PR DESCRIPTION
In Django 4.1, CheckboxSelectMultiple is a subclass of RadioSelect, so this no longer makes a lot of sense