### PR TITLE
Add support for Django 5.1, remove Python 3.12 restriction on Django 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,19 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
-        django-version: [4.2, 5.0, "main"]
+        django-version: [4.2, 5.0, 5.1, "main"]
         exclude:
-            # Django 4.2
-            - python-version: 3.12
-              django-version: 4.2
-
             # Django 5.0
             - python-version: 3.8
               django-version: 5.0
             - python-version: 3.9
               django-version: 5.0
+
+            # Django 5.1
+            - python-version: 3.8
+              django-version: 5.1
+            - python-version: 3.9
+              django-version: 5.1
 
             # Django main
             - python-version: 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleases
+
+- Add support for Django 5.1 (#1013)
+
 ## 24.2 (2024-04-17)
 
 - Reinstate setuptools_scm for build (#965).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Framework :: Django",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",


### PR DESCRIPTION
* Django 5.1 was release on 2024-08-07 https://docs.djangoproject.com/en/5.1/releases/5.1/
* Django 4.2 supports Python 3.12 since release 4.2.8 https://docs.djangoproject.com/en/5.0/releases/4.2/