### PR TITLE
Drop Django 4.2 (EOL), add Django 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,18 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.2", "6.0", "main"]
+        django-version: ["5.2", "6.0", "6.1", "main"]
         exclude:
-          # Django 4.2
-          - python-version: "3.14"
-            django-version: "4.2"
           # Django 6.0
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          # Django 6.1
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
           # Django main
           - python-version: "3.10"
             django-version: "main"
@@ -70,7 +72,7 @@ jobs:
           if [ "${{ matrix.django-version }}" = "main" ]; then
             uv pip install "https://github.com/django/django/archive/main.tar.gz"
           else
-            uv pip install "Django==${{ matrix.django-version }}.*"
+            uv pip install --prerelease allow "Django==${{ matrix.django-version }}.*"
           fi
 
       - name: Debug - Show versions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,11 +98,11 @@ Test matrix (tox) — not a full grid:
 
 | Python  | Django versions         |
 |---------|-------------------------|
-| 3.10    | 4.2, 5.2                |
-| 3.11    | 4.2, 5.2                |
-| 3.12    | 4.2, 5.2, 6.0, main     |
-| 3.13    | 4.2, 5.2, 6.0, main     |
-| 3.14    | 5.2, 6.0, main          |
+| 3.10    | 5.2                     |
+| 3.11    | 5.2                     |
+| 3.12    | 5.2, 6.0, 6.1, main     |
+| 3.13    | 5.2, 6.0, 6.1, main     |
+| 3.14    | 5.2, 6.0, 6.1, main     |
 
 Target the matrix when adding features; avoid Django-version-specific code paths where possible.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add support for Django 6.1.
+- Drop support for Django 4.2 (EOL).
+
 ## 26.1 (2026-01-03)
 
 - Refactor release workflow to tag-based publishing via GitHub Actions (#1102).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Topic :: Utilities",
 ]
-dependencies = ["Django>=4.2"]
+dependencies = ["Django>=5.2"]
 description = "Bootstrap 3 for Django"
 keywords = ["django", "bootstrap", "bootstrap3"]
 license = "BSD-3-Clause"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ requires =
     tox>=4.2
 args_are_paths = false
 envlist =
-    py310-{4.2,5.2},
-    py311-{4.2,5.2},
-    py312-{4.2,5.2,6.0,main},
-    py313-{4.2,5.2,6.0,main},
-    py314-{5.2,6.0,main},
+    py310-{5.2},
+    py311-{5.2},
+    py312-{5.2,6.0,6.1,main},
+    py313-{5.2,6.0,6.1,main},
+    py314-{5.2,6.0,6.1,main},
 
 [testenv]
 runner = uv-venv-runner
@@ -20,7 +20,7 @@ commands =
 dependency_groups =
     test
 deps =
-    4.2: Django==4.2.*
     5.2: Django==5.2.*
     6.0: Django==6.0.*
+    6.1: Django==6.1.*
     main: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
## Summary
Same fix as zostera/django-bootstrap5#842 and #843, applied here. This is maintenance-mode compatibility work (per AGENTS.md), not a new feature.

- Django 4.2 LTS reached end of life on 2026-04-07 — dropped, floor bumped to `>=5.2`.
- Django's `main` branch has moved to `6.2.0-alpha`, meaning 6.1 has split into its own `stable/6.1.x` branch (RC1 published, final expected ~August 2026) — added now per policy of tracking `main`'s divergence rather than waiting for the final release.
- CI's Django install step needed `--prerelease allow` since only `6.1rc1` exists on PyPI right now.

## Test plan
- [x] `just test` — 64 passed
- [x] `just lint` — all checks passed
- [x] Full tox matrix (all 14 envs) — all green, confirmed `main` resolves to Django 6.2.dev and `6.1` resolves to `6.1rc1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)