### PR TITLE
Add MAINTAINING.md; scope + PR checklist in CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,15 +94,7 @@ tests/
     test_version.py
 ```
 
-Test matrix (tox) — not a full grid:
-
-| Python  | Django versions         |
-|---------|-------------------------|
-| 3.10    | 4.2, 5.2                |
-| 3.11    | 4.2, 5.2                |
-| 3.12    | 4.2, 5.2, 6.0, main     |
-| 3.13    | 4.2, 5.2, 6.0, main     |
-| 3.14    | 5.2, 6.0, main          |
+The current Python × Django matrix is not a full grid — see `tox.ini`'s `envlist` for what's actually tested (`pyproject.toml` classifiers and `ci.yml`'s matrix must match it). Don't copy the matrix into prose elsewhere; it drifts. See [MAINTAINING.md](MAINTAINING.md) for the policy behind how the matrix is chosen and kept current.
 
 Target the matrix when adding features; avoid Django-version-specific code paths where possible.
 
@@ -114,11 +106,4 @@ GitHub Actions runs on every push and PR:
 
 `just lint` must pass before committing — CI enforces it and will fail the PR.
 
-## Release process
-
-1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
-2. Commit and push to `main`
-3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
-4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
-
-`just release-tag` requires: clean working directory AND current branch is `main`. It will fail otherwise.
+See [MAINTAINING.md](MAINTAINING.md) for the release process and version-support policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
+
 ## 26.1 (2026-01-03)
 
 - Refactor release workflow to tag-based publishing via GitHub Actions (#1102).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,15 @@ little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
+## Scope
+
+This project is in **maintenance mode** — Bootstrap 3 has been superseded by Bootstrap 4 and
+5. Only bug fixes and security updates are accepted; new features or enhancements are out of
+scope and will be closed, however well-implemented, unless they're needed to keep the package
+working against a currently-supported Python/Django release. If you're starting something new,
+use [django-bootstrap5](https://github.com/zostera/django-bootstrap5) instead. Worth opening an
+issue to confirm scope before investing time in a pull request.
+
 ## Types of Contributions
 
 ### Report Bugs
@@ -19,11 +28,7 @@ If you are reporting a bug, please include:
 
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with \"bug\" is open to whoever wants to implement it.
-
-### Implement Features
-
-Look through the GitHub issues for features. Anything tagged with \"feature\" is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to whoever wants to implement it.
 
 ### Write Documentation
 
@@ -34,14 +39,9 @@ Look through the GitHub issues for features. Anything tagged with \"feature\" is
 The best way to send feedback is to file an issue at
 <https://github.com/zostera/django-bootstrap3/issues>.
 
-If you are proposing a feature:
-
-- Explain in detail how it would work.
-- Keep the scope as narrow as possible, to make it easier to implement.
-
 ## Get Started!
 
-Ready to contribute? Here\'s how to set up `django-bootstrap3` for local development.
+Ready to contribute? Here's how to set up `django-bootstrap3` for local development.
 
 You will need some knowledge of git, github, and Python/Django development. Using a Python virtual environment is advised.
 
@@ -75,5 +75,13 @@ just tests
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests for new or changed functionality, and pass all tests.
-2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in CHANGELOG.md.
+1. It fits the project's [scope](#scope) — bug fixes and compatibility only. If in doubt, open an issue first.
+2. It includes tests for new or changed functionality, and passes all existing tests (`just test`).
+3. It doesn't change the rendered markup of an existing widget unless that's the explicit
+   point of the PR — existing users depend on the current output.
+4. It doesn't add a new runtime dependency without discussing it in an issue first.
+5. The change is added to `CHANGELOG.md`.
+
+Pull requests that don't meet these may be asked for changes, or closed if they've gone stale
+without a response — see [MAINTAINING.md](MAINTAINING.md) for how the project handles review
+backlog and version support.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,39 @@
+# Maintaining django-bootstrap3
+
+Notes for maintainers. For how to submit a contribution, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Maintenance mode
+
+This package is in maintenance mode (see AGENTS.md and CONTRIBUTING.md) — only bug fixes,
+security updates, and Python/Django compatibility are in scope. The policy below still
+applies to compatibility work even though the package accepts no new features.
+
+## Version support policy
+
+These are rules, not a snapshot of current versions — the current matrix lives in `tox.ini`
+(`envlist`), `.github/workflows/ci.yml` (the `python_django_matrix` job), and `pyproject.toml`
+(classifiers + `dependencies`). Those three files are the source of truth and must agree with
+each other. Don't restate the matrix as a table in prose docs (AGENTS.md, README, etc.) — a
+copy always drifts out of sync with the files that actually enforce it.
+
+- Support every Python and Django release cycle that is not end-of-life, per
+  [endoflife.date/python](https://endoflife.date/python) and
+  [endoflife.date/django](https://endoflife.date/django). Drop a cycle from the matrix as soon
+  as it goes EOL — don't wait for a scheduled release to do it.
+- Always track Django's `main` branch in the matrix. Add a new Django release series
+  (e.g. 6.1) alongside `main` as soon as `main` has diverged from it — i.e. once upstream
+  cuts a `stable/X.Y.x` branch and `main` itself moves on to the next alpha. Don't wait for
+  the new series' final release.
+- Add a new Python pre-release as a **non-blocking** CI job (`continue-on-error: true`) as
+  soon as it's installable — `uv python install` can usually fetch a new CPython the same day
+  it's cut, so the interpreter itself is rarely the blocker. Only make the job blocking once
+  test dependencies with C extensions publish wheels for it, if any are in use.
+
+## Release process
+
+1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
+2. Commit and push to `main`
+3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
+4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+
+`just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.


### PR DESCRIPTION
## Summary
Same docs added to zostera/django-bootstrap5#844, adapted for this package's maintenance-mode status:

- **New `MAINTAINING.md`** — version-support policy as rules, not a version snapshot (same wording as django-bootstrap5's), plus a note that the package's maintenance-mode status doesn't exempt it from Python/Django compatibility work. States that `tox.ini`/`ci.yml`/`pyproject.toml` are the sole source of truth for the actual matrix. Also moved "Release process" here from AGENTS.md.
- **`AGENTS.md`** — replaced the hardcoded Python×Django matrix table with a pointer to `tox.ini`; replaced the Release process section with a pointer to MAINTAINING.md.
- **`CONTRIBUTING.md`** — added a `## Scope` section folding in the existing maintenance-mode note (bug fixes/security/compat only, point new work at django-bootstrap5) and expanded the PR guidelines into a checklist. Removed the now-inapplicable "Implement Features" contribution type. Fixed stray escaped-quote artifacts left over in the file's prose.

## Test plan
- [x] `just test` — 64 passed
- [x] `just lint` — all checks passed
- [x] `just docs` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)