### PR TITLE
Remove IS_DJANGO5/DJANGO_VERSION dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove `IS_DJANGO5`/`DJANGO_VERSION` from `bootstrap3.utils` — dead now that the Django floor is 5.2 (was a compatibility bridge for pre-5.0 aria-describedby rendering).
 - Add support for Django 6.1.
 - Drop support for Django 4.2 (EOL).
 

--- a/src/bootstrap3/utils.py
+++ b/src/bootstrap3/utils.py
@@ -1,7 +1,6 @@
 import re
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
-from django import get_version
 from django.forms.utils import flatatt
 from django.template import Variable, VariableDoesNotExist
 from django.template.base import FilterExpression, TemplateSyntaxError, kwarg_re
@@ -13,9 +12,6 @@ from django.utils.safestring import mark_safe
 from bootstrap3.exceptions import BootstrapError
 
 from .text import text_value
-
-DJANGO_VERSION = get_version()
-IS_DJANGO5 = DJANGO_VERSION >= "5"
 
 # RegEx for quoted string
 QUOTED_STRING = re.compile(r'^["\'](?P<noquotes>.+)["\']$')

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from bootstrap3.exceptions import BootstrapError
 from bootstrap3.text import text_concat, text_value
 from bootstrap3.utils import (
-    IS_DJANGO5,
     add_css_class,
     render_tag,
     url_to_attrs_dict,
@@ -169,8 +168,7 @@ class FieldTest(TestCase):
 
     def test_checkbox(self):
         res = render_form_field("cc_myself")
-        if IS_DJANGO5:
-            res = res.replace('aria-describedby="id_cc_myself_helptext"', "")
+        res = res.replace('aria-describedby="id_cc_myself_helptext"', "")
         self.assertHTMLEqual(
             """
 <div class="form-group">


### PR DESCRIPTION
## Summary
Checked for Django-version-conditional code left over from before the 4.2 drop (#1124). Found: `bootstrap3.utils.IS_DJANGO5`/`DJANGO_VERSION` existed solely to bridge pre-5.0-vs-5.0+ \`aria-describedby\` rendering differences (used in exactly one test). Now that the Django floor is 5.2, that condition is always true — inlined the branch and removed the now-dead constants and their only import.

## Test plan
- [x] `just test` — 64 passed
- [x] `just lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)