### PR TITLE
Fix XSS in auto-generated placeholder attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix XSS: a field `label` containing a quote could break out of the auto-generated `placeholder` attribute and inject arbitrary HTML/JS, because the placeholder value was wrapped in `mark_safe()` before being written into the widget's attrs.
 - Remove `IS_DJANGO5`/`DJANGO_VERSION` from `bootstrap3.utils` — dead now that the Django floor is 5.2 (was a compatibility bridge for pre-5.0 aria-describedby rendering).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Add support for Django 6.1.

--- a/src/bootstrap3/renderers.py
+++ b/src/bootstrap3/renderers.py
@@ -236,7 +236,7 @@ class FieldRenderer(BaseRenderer):
             # Or just set it to empty
             self.placeholder = ""
         if self.placeholder:
-            self.placeholder = text_value(mark_safe(self.placeholder))
+            self.placeholder = text_value(self.placeholder)
 
         self.addon_before = kwargs.get("addon_before", self.widget.attrs.pop("addon_before", ""))
         self.addon_after = kwargs.get("addon_after", self.widget.attrs.pop("addon_after", ""))

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 import re
 
+from django import forms
 from django.contrib.messages import constants as DEFAULT_MESSAGE_LEVELS
 from django.forms import formset_factory
 from django.test import TestCase
@@ -165,6 +166,21 @@ class FieldTest(TestCase):
     def test_illegal_field(self):
         with self.assertRaises(BootstrapError):
             render_field(field="illegal")
+
+    def test_placeholder_xss(self):
+        """A label containing a quote must not break out of the auto-generated placeholder attribute."""
+
+        class XssTestForm(forms.Form):
+            xss_field = forms.CharField(label='XSS" onmouseover="alert(1)" foo="', max_length=100)
+
+        res = render_template_with_form("{% bootstrap_field form.xss_field %}", {"form": XssTestForm()})
+        # The label breaking out of the placeholder attribute would inject a live
+        # onmouseover handler on the <input> — must render as escaped text instead.
+        self.assertNotIn('onmouseover="alert(1)"', res)
+        self.assertIn(
+            'placeholder="XSS&quot; onmouseover=&quot;alert(1)&quot; foo=&quot;"',
+            res,
+        )
 
     def test_checkbox(self):
         res = render_form_field("cc_myself")


### PR DESCRIPTION
FieldRenderer` wrapped the auto-generated `placeholder` value in `mark_safe()` before writing it into `widget.attrs["placeholder"]`. Unnecessary use of `mark_safe`, already gone in `django-bootstrap4` and `django-bootstrap5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)