### PR TITLE
Note Bootstrap 3.4.1 is final in MAINTAINING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Note in MAINTAINING.md that the pinned Bootstrap 3.4.1 CDN version is confirmed final (no 3.x releases expected), matching the note already in django-bootstrap4.
 - Fix XSS: a field `label` containing a quote could break out of the auto-generated `placeholder` attribute and inject arbitrary HTML/JS, because the placeholder value was wrapped in `mark_safe()` before being written into the widget's attrs.
 - Remove `IS_DJANGO5`/`DJANGO_VERSION` from `bootstrap3.utils` — dead now that the Django floor is 5.2 (was a compatibility bridge for pre-5.0 aria-describedby rendering).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -29,6 +29,13 @@ copy always drifts out of sync with the files that actually enforce it.
   it's cut, so the interpreter itself is rarely the blocker. Only make the job blocking once
   test dependencies with C extensions publish wheels for it, if any are in use.
 
+### Bootstrap
+
+The default CDN URL is pinned to Bootstrap 3.4.1 — confirmed to be the final 3.x release
+(Bootstrap itself has moved on to 5.x, no further 3.x releases are expected). Nothing to
+monitor here under normal circumstances; only revisit if upstream unexpectedly cuts a new
+3.x patch.
+
 ## Release process
 
 1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`


### PR DESCRIPTION
## Summary
Confirmed via jsdelivr that Bootstrap 3.4.1 (already pinned) is the final 3.x release upstream — matching the equivalent note already in `django-bootstrap4`'s `MAINTAINING.md`.

**Dropped from this PR**: the original version also removed the `type="link"` attribute for `bootstrap_button(button_type="link")`. On reflection, that's not worth doing — an unrecognized `type` value on `<button>` makes browsers fall back to the default `type="submit"` behavior, identical to omitting `type` entirely. So the change had zero functional effect, only a cosmetic HTML-validity difference, while still altering rendered output for anyone relying on it (however unlikely). Under this package's maintenance-mode policy (bug fixes only, no unforced behavior changes), that's not a fix worth making. Reverted, keeping only the docs note.

## Test plan
- [x] `just test` — 65 passed
- [x] `just lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)