### PR TITLE
Revert "Release 26.2" (was pushed directly to main by mistake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 26.2 (2026-07-30)
+## Unreleased
 
 - Note in MAINTAINING.md that the pinned Bootstrap 3.4.1 CDN version is confirmed final (no 3.x releases expected), matching the note already in django-bootstrap4.
 - Fix XSS: a field `label` containing a quote could break out of the auto-generated `placeholder` attribute and inject arbitrary HTML/JS, because the placeholder value was wrapped in `mark_safe()` before being written into the widget's attrs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 name = "django-bootstrap3"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "26.2"
+version = "26.1"
 
 [project.urls]
 Changelog = "https://github.com/zostera/django-bootstrap3/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Commit d055391 was pushed straight to `main`, bypassing PR review and branch protection — should never have happened
- This reverts it cleanly (no tag was cut, no PyPI publish triggered, so nothing beyond the direct commit needs undoing)
- The actual 26.2 version bump will be redone properly on its own branch/PR

## Test plan
- [x] Pure revert, restores previous CHANGELOG.md/pyproject.toml content