### PR TITLE
Release 26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 26.2 (2026-07-30)
 
 - Note in MAINTAINING.md that the pinned Bootstrap 3.4.1 CDN version is confirmed final (no 3.x releases expected), matching the note already in django-bootstrap4.
 - Fix XSS: a field `label` containing a quote could break out of the auto-generated `placeholder` attribute and inject arbitrary HTML/JS, because the placeholder value was wrapped in `mark_safe()` before being written into the widget's attrs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 name = "django-bootstrap3"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "26.1"
+version = "26.2"
 
 [project.urls]
 Changelog = "https://github.com/zostera/django-bootstrap3/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Bumps CHANGELOG.md's Unreleased section to 26.2 (2026-07-30) and pyproject.toml version to match
- Includes the XSS placeholder-attribute fix (#1127), Django 6.1 support, dropped Django 4.2 (EOL), and doc/policy updates already merged to main

## Test plan
- [ ] After merge: `just build` then `just release-tag` from main